### PR TITLE
Ordered relations in TimebasedBucketizer and PagedBucketizer

### DIFF
--- a/configs/bucketizer_configs.ttl
+++ b/configs/bucketizer_configs.ttl
@@ -72,6 +72,18 @@
     sh:datatype xsd:integer;
     sh:maxCount 1;
     sh:minCount 1;
+  ], [
+    sh:name "path";
+    sh:path tree:timestampPath;
+    sh:class rdfl:PathLens;
+    sh:maxCount 1;
+    sh:minCount 0;
+  ], [
+    sh:name "pathQuads";
+    sh:path tree:timestampPath;
+    sh:class <RdfThing>;
+    sh:maxCount 1;
+    sh:minCount 0;
   ].
 
 [ ] a sh:NodeShape;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rdfc/sds-processors-ts",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rdfc/sds-processors-ts",
-      "version": "1.0.0",
+      "version": "1.1.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@treecg/types": "^0.4.6",
@@ -515,6 +515,7 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.18.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.4",
@@ -527,6 +528,7 @@
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -535,6 +537,7 @@
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -545,6 +548,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -566,6 +570,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -574,6 +579,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -584,6 +590,7 @@
     },
     "node_modules/@eslint/js": {
       "version": "9.9.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -591,6 +598,7 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.4",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -660,6 +668,7 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.3.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -2179,6 +2188,7 @@
     },
     "node_modules/eslint": {
       "version": "9.9.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -2246,6 +2256,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.0.2",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -2270,6 +2281,7 @@
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2278,6 +2290,7 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2288,6 +2301,7 @@
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2298,6 +2312,7 @@
     },
     "node_modules/espree": {
       "version": "10.1.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.12.0",
@@ -2313,6 +2328,7 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "4.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2487,6 +2503,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -2539,6 +2556,7 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -2689,6 +2707,7 @@
     },
     "node_modules/globals": {
       "version": "14.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4207,17 +4226,6 @@
         "hash.js": "^1.1.7",
         "rdf-string": "^1.6.0",
         "rdf-terms": "^1.7.0"
-      }
-    },
-    "node_modules/rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
-      "deprecated": "Use @types/rdf-js instead. See https://github.com/rdfjs/types?tab=readme-ov-file#what-about-typesrdf-js",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@rdfjs/types": "*"
       }
     },
     "node_modules/rdf-lens": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdfc/sds-processors-ts",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.0",
   "type": "module",
   "scripts": {
     "build": "tspc && tsc-alias",

--- a/src/bucketizers/index.ts
+++ b/src/bucketizers/index.ts
@@ -37,6 +37,8 @@ export type SubjectFragmentation = {
 
 export type PageFragmentation = {
     pageSize: number;
+    path?: BasicLensM<Cont, Cont>;
+    pathQuads?: Cont;
 };
 
 export type TimebasedFragmentation = {

--- a/src/bucketizers/pagedBucketizer.ts
+++ b/src/bucketizers/pagedBucketizer.ts
@@ -1,24 +1,43 @@
 import { AddRelation, Bucketizer, PageFragmentation } from "./index";
-import { Bucket, Record } from "../utils";
-import { TREE } from "@treecg/types";
+import { Bucket, RdfThing, Record } from "../utils";
+import { TREE, XSD } from "@treecg/types";
 import { getLoggerFor } from "../utils/logUtil";
+import { BasicLensM, Cont } from "rdf-lens";
+import { Term } from "@rdfjs/types";
+import { DataFactory } from "n3";
+
+const { literal, namedNode } = DataFactory;
 
 export default class PagedBucketizer implements Bucketizer {
     protected readonly logger = getLoggerFor(this);
 
     private readonly pageSize: number;
+    private readonly path: BasicLensM<Cont, { value: string; literal?: Term }>;
+    private readonly pathQuads: RdfThing;
     private count: number = 0;
+    private lastMemberTimestamp: number = 0;
 
     constructor(config: PageFragmentation, save?: string) {
         this.pageSize = config.pageSize;
 
+        if (config.path && config.pathQuads) {
+            // Timestamp path is set, so we have an ordered paged bucketizer.
+            this.path = config.path.mapAll((x) => ({
+                value: x.id.value,
+                literal: x.id,
+            }));
+            this.pathQuads = config.pathQuads;
+        }
+
         if (save) {
-            this.count = JSON.parse(save);
+            const parsed = JSON.parse(save);
+            this.count = parsed.count;
+            this.lastMemberTimestamp = parsed.lastMemberTimestamp;
         }
     }
 
     bucketize(
-        _: Record,
+        record: Record,
         getBucket: (key: string, root?: boolean) => Bucket,
         addRelation: AddRelation,
     ): Bucket[] {
@@ -26,10 +45,53 @@ export default class PagedBucketizer implements Bucketizer {
         this.count += 1;
         const currentbucket = getBucket("page-" + index, index == 0);
 
+        let recordTimestamp: Date | undefined = undefined;
+        if (this.path) {
+            const values = this.path
+                .execute(record.data)
+                .filter(
+                    (x, i, arr) =>
+                        arr.findIndex((y) => x.value === y.value) == i,
+                )
+                .filter((value) => value.literal);
+
+            if (values.length !== 1) {
+                this.logger.error(
+                    `Expected exactly one timestamp value, got ${values.length}. Ignoring record '${record.data.id.value}'.`,
+                );
+                return [];
+            }
+
+            recordTimestamp = new Date(values[0].literal!.value);
+
+            // Check if the record is out of order.
+            if (recordTimestamp.getTime() < this.lastMemberTimestamp) {
+                this.logger.error(
+                    `Record timestamp is before the last record timestamp. Are your records out of order? Ignoring record '${record.data.id.value}'.`,
+                );
+                return [];
+            }
+            this.lastMemberTimestamp = recordTimestamp.getTime();
+        }
+
         if (this.count % this.pageSize == 1 && this.count > 1) {
             const oldBucket = getBucket("page-" + (index - 1), index - 1 == 0);
             oldBucket.immutable = true;
-            addRelation(oldBucket, currentbucket, TREE.terms.Relation);
+            if (recordTimestamp) {
+                // Ordered paged bucketizer, add a ≥ relation to the previous bucket.
+                addRelation(
+                    oldBucket,
+                    currentbucket,
+                    TREE.terms.GreaterThanOrEqualToRelation,
+                    literal(
+                        recordTimestamp.toISOString(),
+                        namedNode(XSD.dateTime),
+                    ),
+                    this.pathQuads,
+                );
+            } else {
+                addRelation(oldBucket, currentbucket, TREE.terms.Relation);
+            }
             this.logger.info(`Created new page bucket ${index}`);
         }
 
@@ -37,6 +99,9 @@ export default class PagedBucketizer implements Bucketizer {
     }
 
     save() {
-        return JSON.stringify(this.count);
+        return JSON.stringify({
+            count: this.count,
+            lastMemberTimestamp: this.lastMemberTimestamp,
+        });
     }
 }

--- a/src/bucketizers/timebasedBucketizer.ts
+++ b/src/bucketizers/timebasedBucketizer.ts
@@ -117,6 +117,16 @@ export default class TimebasedBucketizer implements Bucketizer {
                         );
                         return [];
                     } else if (
+                        this.members.length > 0 &&
+                        recordTimestamp.getTime() <
+                            this.members[this.members.length - 1].timestamp
+                    ) {
+                        // The record is out of order. This should not happen.
+                        this.logger.error(
+                            `Record timestamp is before the last record timestamp. Are your records out of order? Ignoring record '${record.data.id.value}'.`,
+                        );
+                        return [];
+                    } else if (
                         recordTimestamp.getTime() >=
                         bucketTimestamp.getTime() + bucketSpan
                     ) {
@@ -172,7 +182,9 @@ export default class TimebasedBucketizer implements Bucketizer {
                         addRelation(
                             candidateBucket,
                             newBucket,
-                            TREE.terms.Relation,
+                            TREE.terms.GreaterThanOrEqualToRelation,
+                            literal(timestamp, namedNode(XSD.dateTime)),
+                            this.pathQuads,
                         );
 
                         // Update the members for the new bucket.


### PR DESCRIPTION
Using Greater than or equal relations instead of normal relations where possible, will allow the ldes-client to already emit found members when run in ascending order mode.

For the TimebasedBucketizer, it was already a requirement that members were ingested in order, so we can just use a ≥ relation there.

For the PagedBucketizer, I added an optional `timestampPath` parameter, when set, it will consider the paged bucketizer as an ordered one, and will check that members are ingested in order. It will then also use the ≥ relation to link to the next page.