### PR TITLE
Only update the saves if the bucketizer was actually used

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,7 +2,7 @@ name: Build & Test with Bun
 
 on:
     push:
-        branches: [ master ]
+        branches: [ master, renovate/** ]
     pull_request:
         branches: [ master ]
 

--- a/src/bucketizers/index.ts
+++ b/src/bucketizers/index.ts
@@ -14,9 +14,9 @@ import SubjectBucketizer from "./subjectBucketizer";
 import TimebasedBucketizer from "./timebasedBucketizer";
 import { $INLINE_FILE } from "@ajuvercr/ts-transformer-inline-file";
 import TimeBucketBucketizer, { TimeBucketTreeConfig } from "./timeBucketTree";
+import HourBucketizer from "./hourBucketizer";
 
 export { TimeBucketTreeConfig } from "./timeBucketTree";
-import HourBucketizer from "./hourBucketizer";
 
 const df = new DataFactory();
 export const SHAPES_TEXT = $INLINE_FILE("../../configs/bucketizer_configs.ttl");
@@ -223,8 +223,11 @@ export class BucketizerOrchestrator {
 
     save(): string {
         for (const key of Object.keys(this.saves)) {
-            this.saves[key].save = this.saves[key].bucketizer?.save();
-            delete this.saves[key].bucketizer;
+            // Only update the saves for a key, if the bucketizer was actually used
+            if (this.saves[key].bucketizer) {
+                this.saves[key].save = this.saves[key].bucketizer?.save();
+                delete this.saves[key].bucketizer;
+            }
         }
         return JSON.stringify(this.saves);
     }


### PR DESCRIPTION
When a pipeline was initiated containing a bucketizer processor, but no data was streamed to the bucketizer, after the pipeline finishes, it would reset the saved buckets, because a `bucketizer` on `this.saves[key]` is only initiated when the `getBucketizer` is called as a result of `channels.dataInput.data(`.
`this.saves[key].save = this.saves[key].bucketizer?.save();` would result in undefined, as `this.saves[key].bucketizer` is undefined in this case, removing the saved buckets as a result.

This PR fixes this by checking if a bucketizer was initiated for the key, indicating that the saved buckets could have been updated.