### PR TITLE
fix(LdesDiskWriter): Internal Quad structure cannot handle relative URIs so use a base IRI during processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "csv-parse": "^5.6.0",
         "extract-cbd-shape": "^0.1.12",
         "jsonld": "^8.3.3",
-        "n3": "^1.24.2",
+        "n3": "github:smessie/N3.js#relative-parent-references",
         "rdf-canonize": "^4.0.1",
         "rdf-data-factory": "^2.0.2",
         "rdf-lens": "^1.3.5",
@@ -1767,6 +1767,21 @@
       },
       "bin": {
         "js-runner": "bin/js-runner.js"
+      }
+    },
+    "node_modules/@rdfc/js-runner/node_modules/n3": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.24.2.tgz",
+      "integrity": "sha512-j/3PKmK0MA3tAohDCl9y1JDaNxp8wCnhTtrOOgZ1O17JVtWLkzHsp2jZ8YhY2uS4FWQAm6mExcXvl7C8lwXyaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "queue-microtask": "^1.1.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/@rdfjs/types": {
@@ -3883,6 +3898,20 @@
         "rdf-stores": "^2.1.1"
       }
     },
+    "node_modules/extract-cbd-shape/node_modules/n3": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.24.2.tgz",
+      "integrity": "sha512-j/3PKmK0MA3tAohDCl9y1JDaNxp8wCnhTtrOOgZ1O17JVtWLkzHsp2jZ8YhY2uS4FWQAm6mExcXvl7C8lwXyaw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "queue-microtask": "^1.1.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5556,13 +5585,11 @@
       }
     },
     "node_modules/n3": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.24.2.tgz",
-      "integrity": "sha512-j/3PKmK0MA3tAohDCl9y1JDaNxp8wCnhTtrOOgZ1O17JVtWLkzHsp2jZ8YhY2uS4FWQAm6mExcXvl7C8lwXyaw==",
+      "version": "1.17.3",
+      "resolved": "git+ssh://git@github.com/smessie/N3.js.git#a64f6cbab292af1ba1c4508db27e8c204f080f52",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
-        "queue-microtask": "^1.1.2",
         "readable-stream": "^4.0.0"
       },
       "engines": {
@@ -6123,6 +6150,20 @@
         "@types/n3": "^1.21.1",
         "n3": "^1.23.1",
         "rdf-data-factory": "^2.0.2"
+      }
+    },
+    "node_modules/rdf-lens/node_modules/n3": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.24.2.tgz",
+      "integrity": "sha512-j/3PKmK0MA3tAohDCl9y1JDaNxp8wCnhTtrOOgZ1O17JVtWLkzHsp2jZ8YhY2uS4FWQAm6mExcXvl7C8lwXyaw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "queue-microtask": "^1.1.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/rdf-stores": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rdfc/sds-processors-ts",
-  "version": "1.4.0",
+  "version": "1.4.1-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rdfc/sds-processors-ts",
-      "version": "1.4.0",
+      "version": "1.4.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@treecg/types": "^0.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "csv-parse": "^5.6.0",
         "extract-cbd-shape": "^0.1.12",
         "jsonld": "^8.3.3",
-        "n3": "github:smessie/N3.js#relative-parent-references",
+        "n3": "1.25.1",
         "rdf-canonize": "^4.0.1",
         "rdf-data-factory": "^2.0.2",
         "rdf-lens": "^1.3.5",
@@ -1767,21 +1767,6 @@
       },
       "bin": {
         "js-runner": "bin/js-runner.js"
-      }
-    },
-    "node_modules/@rdfc/js-runner/node_modules/n3": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.24.2.tgz",
-      "integrity": "sha512-j/3PKmK0MA3tAohDCl9y1JDaNxp8wCnhTtrOOgZ1O17JVtWLkzHsp2jZ8YhY2uS4FWQAm6mExcXvl7C8lwXyaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "queue-microtask": "^1.1.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/@rdfjs/types": {
@@ -3898,20 +3883,6 @@
         "rdf-stores": "^2.1.1"
       }
     },
-    "node_modules/extract-cbd-shape/node_modules/n3": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.24.2.tgz",
-      "integrity": "sha512-j/3PKmK0MA3tAohDCl9y1JDaNxp8wCnhTtrOOgZ1O17JVtWLkzHsp2jZ8YhY2uS4FWQAm6mExcXvl7C8lwXyaw==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "queue-microtask": "^1.1.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5585,8 +5556,9 @@
       }
     },
     "node_modules/n3": {
-      "version": "1.17.3",
-      "resolved": "git+ssh://git@github.com/smessie/N3.js.git#a64f6cbab292af1ba1c4508db27e8c204f080f52",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.25.1.tgz",
+      "integrity": "sha512-5vqp6Wcolb57WLC4DC0Nf6ieFPnTOLWwvIG0mmSzTpcRcNyd7xquVSlYSU6clvAZUEfs/OHWGNDRNwQi+m912Q==",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
@@ -6021,6 +5993,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6150,20 +6123,6 @@
         "@types/n3": "^1.21.1",
         "n3": "^1.23.1",
         "rdf-data-factory": "^2.0.2"
-      }
-    },
-    "node_modules/rdf-lens/node_modules/n3": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.24.2.tgz",
-      "integrity": "sha512-j/3PKmK0MA3tAohDCl9y1JDaNxp8wCnhTtrOOgZ1O17JVtWLkzHsp2jZ8YhY2uS4FWQAm6mExcXvl7C8lwXyaw==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "queue-microtask": "^1.1.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/rdf-stores": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "csv-parse": "^5.6.0",
     "extract-cbd-shape": "^0.1.12",
     "jsonld": "^8.3.3",
-    "n3": "^1.24.2",
+    "n3": "github:smessie/N3.js#relative-parent-references",
     "rdf-canonize": "^4.0.1",
     "rdf-data-factory": "^2.0.2",
     "rdf-lens": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdfc/sds-processors-ts",
-  "version": "1.4.0",
+  "version": "1.4.1-alpha.0",
   "type": "module",
   "scripts": {
     "build": "tspc && tsc-alias",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "csv-parse": "^5.6.0",
     "extract-cbd-shape": "^0.1.12",
     "jsonld": "^8.3.3",
-    "n3": "github:smessie/N3.js#relative-parent-references",
+    "n3": "1.25.1",
     "rdf-canonize": "^4.0.1",
     "rdf-data-factory": "^2.0.2",
     "rdf-lens": "^1.3.5",


### PR DESCRIPTION
Relative IRIs are allowed in Turtle, but when the N3 Parser parses the Turtle to their internal general Quad structure, no relative URIs are allowed and the parser tries to interpret them as full URIs. Without passing a base URI, the deepness of the relative URIs is getting lost, so we fix this by passing a custom base IRI with enough path levels so we can restore the relative URIs after processing the content with the N3 Parser and Writer.